### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -95,7 +95,7 @@ def load_and_process_data() -> pd.DataFrame:
         rows.extend(page["buildings"])
         offset += _PAGE_SIZE
 
-    logger.info(f"Loaded {len(rows)} building records from API (total reported: {total})")
+    logger.info("Loaded %d building records from API", len(rows))
 
     df = pd.DataFrame(rows)
 


### PR DESCRIPTION
Potential fix for [https://github.com/Banamangas/FoE-Buildings-Database/security/code-scanning/1](https://github.com/Banamangas/FoE-Buildings-Database/security/code-scanning/1)

General approach: Avoid logging values that are (or are considered) derived from secrets or other sensitive inputs. Where logging is still desired, log only static text or values known to be non-sensitive, or explicitly sanitize/decouple them from tainted data.

Best concrete fix here: On line 98 in `data_loader.py`, the log message currently includes both `len(rows)` (count of loaded records) and `total` (count reported by the API response, which CodeQL treats as tainted). To satisfy the analyzer and avoid any possibility of leaking tainted data, we can either remove the log entirely or log only non-tainted information. Since `len(rows)` is computed locally from the aggregated list and does not depend on secrets or on the tainted `total`, we can keep a useful log by dropping `total` from the message. That way, the logged string no longer incorporates any tainted value, and the alert is resolved for all variants.

Concretely:
- In `data_loader.py`, update the `logger.info(...)` call around line 98 to no longer interpolate `total`. For example:
  - From: `logger.info(f"Loaded {len(rows)} building records from API (total reported: {total})")`
  - To:   `logger.info("Loaded %d building records from API", len(rows))`
- This also has the advantage of using the logger’s parameterized formatting, which avoids building the full message string when the INFO level is disabled.

No new methods or imports are required; we only modify the single logging line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
